### PR TITLE
Change >= version pins to ~=

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,4 @@ script:
     - ./integration_test_with_setup.sh
     - ./test.sh
     - cat requirements/*.txt >requirements.txt
-    - fossa init
-    - fossa analyze
+    - '[ ! -z "$FOSSA_API_KEY" ] && (fossa init && fossa analyze) || true'

--- a/requirements/ipynb.in
+++ b/requirements/ipynb.in
@@ -2,6 +2,6 @@
 ipykernel==5.1.1
 nbconvert==5.6.0
 jupyter==1.0.0
-jupyter-core==4.5.0
+jupyter-core==4.6.0
 matplotlib==3.1.1
 numpy==1.16.1

--- a/requirements/ipynb.txt
+++ b/requirements/ipynb.txt
@@ -23,7 +23,7 @@ jinja2==2.10.1            # via nbconvert, notebook
 jsonschema==3.0.2         # via nbformat
 jupyter-client==5.3.1     # via ipykernel, jupyter-console, notebook, qtconsole
 jupyter-console==6.0.0    # via jupyter
-jupyter-core==4.5.0
+jupyter-core==4.6.0
 jupyter==1.0.0
 kiwisolver==1.1.0         # via matplotlib
 markupsafe==1.1.1         # via jinja2

--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -31,7 +31,7 @@ jedi==0.14.1              # via ipython
 jinja2==2.10.1            # via nbconvert
 jsonschema==3.0.2         # via nbformat
 jupyter-client==5.3.1     # via ipykernel
-jupyter-core==4.5.0       # via jupyter-client, nbconvert, nbformat
+jupyter-core==4.6.0       # via jupyter-client, nbconvert, nbformat
 markupsafe==1.1.1         # via jinja2
 mistune==0.8.4            # via nbconvert
 more-itertools==7.2.0     # via pytest
@@ -44,7 +44,7 @@ parso==0.5.1              # via jedi
 pexpect==4.7.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pip-compile-multi==1.4.0
-pip-tools==4.0.0          # via pip-compile-multi
+pip-tools==5.0.0          # via pip-compile-multi
 pipreqs==0.4.9
 pluggy==0.12.0            # via pytest
 pre-commit==1.15.2

--- a/setup.py
+++ b/setup.py
@@ -19,20 +19,18 @@ CMD_NAME = "bayesmark"
 # https://packaging.python.org/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup
 REMOVE_FROM_RST = (":func:", ":ref:")
 
+
+def read_requirements(name):
+    with open("requirements/" + name + ".in") as f:
+        requirements = f.read().strip()
+    requirements = requirements.replace("==", "~=").splitlines()  # Loosen strict pins
+    return [pp for pp in requirements if pp[0].isalnum()]
+
+
 # Derive install requires from base.in first order requirements
-with open("requirements/base.in") as f:
-    requirements = f.read().strip()
-requirements = requirements.replace("==", ">=").split()  # Convert to non-pinned for setup.py
-
-with open("requirements/optimizers.in") as f:
-    opt_requirements = f.read().strip()
-opt_requirements = opt_requirements.replace("==", ">=").splitlines()  # Convert to non-pinned for setup.py
-opt_requirements = [pp for pp in opt_requirements if pp[0].isalnum()]
-
-with open("requirements/ipynb.in") as f:
-    ipynb_requirements = f.read().strip()
-ipynb_requirements = ipynb_requirements.replace("==", ">=").splitlines()  # Convert to non-pinned for setup.py
-ipynb_requirements = [pp for pp in ipynb_requirements if pp[0].isalnum()]
+requirements = read_requirements("base")
+opt_requirements = read_requirements("optimizers")
+ipynb_requirements = read_requirements("ipynb")
 
 with open("README.rst") as f:
     long_description = f.read()


### PR DESCRIPTION
>= pins may have Pip pull in a wildly incompatible version of a requirement (upgrading major versions). ~= will use a compatible version (i.e. e.g. the same major.minor but allowing patch upgrades).

Originally spotted by @juhakiili re pip installing pathvalidate >= 2.0, which is incompatible.