### PR TITLE
Remove lambda calls in space

### DIFF
--- a/bayesmark/space.py
+++ b/bayesmark/space.py
@@ -600,9 +600,15 @@ class Categorical(Space):
 
         self.dtype = CAT_DTYPE
         # Debatable if decode should go in unwarp or round_to_values
-        self.warp_f = lambda x: encode(x, self.values, True, WARPED_DTYPE, True)
+        def _encode(x):
+            return encode(x, self.values, True, WARPED_DTYPE, True)
+
+        def _decode(x):
+            return decode(x, self.values, True)
+
+        self.warp_f = _encode
         self.unwarp_f = identity
-        self.round_to_values = lambda y: decode(y, self.values, True)
+        self.round_to_values = _decode
 
         self.lower, self.upper = None, None  # Don't need them
         self.lower_warped = np.zeros(len(values), dtype=WARPED_DTYPE)

--- a/bayesmark/space.py
+++ b/bayesmark/space.py
@@ -601,19 +601,19 @@ class Categorical(Space):
         self.dtype = CAT_DTYPE
         # Debatable if decode should go in unwarp or round_to_values
 
-        def _encode(x):
-            return encode(x, self.values, True, WARPED_DTYPE, True)
-
-        def _decode(x):
-            return decode(x, self.values, True)
-
-        self.warp_f = _encode
+        self.warp_f = self._encode
         self.unwarp_f = identity
-        self.round_to_values = _decode
+        self.round_to_values = self._decode
 
         self.lower, self.upper = None, None  # Don't need them
         self.lower_warped = np.zeros(len(values), dtype=WARPED_DTYPE)
         self.upper_warped = np.ones(len(values), dtype=WARPED_DTYPE)
+
+    def _encode(self, x):
+        return encode(x, self.values, True, WARPED_DTYPE, True)
+
+    def _decode(self, x):
+        return decode(x, self.values, True)
 
     def warp(self, X):
         """Warp inputs to a continuous space.

--- a/bayesmark/space.py
+++ b/bayesmark/space.py
@@ -600,6 +600,7 @@ class Categorical(Space):
 
         self.dtype = CAT_DTYPE
         # Debatable if decode should go in unwarp or round_to_values
+
         def _encode(x):
             return encode(x, self.values, True, WARPED_DTYPE, True)
 


### PR DESCRIPTION
Remove lambda calls in space to make it possible to pickle the object