### PR TITLE
fix: Update lambda functions to methods

### DIFF
--- a/bayesmark/space.py
+++ b/bayesmark/space.py
@@ -599,15 +599,18 @@ class Categorical(Space):
         self.values = values
 
         self.dtype = CAT_DTYPE
-        # Debatable if decode should go in unwarp or round_to_values
-        self.warp_f = lambda x: encode(x, self.values, True, WARPED_DTYPE, True)
         self.unwarp_f = identity
-        self.round_to_values = lambda y: decode(y, self.values, True)
 
         self.lower, self.upper = None, None  # Don't need them
         self.lower_warped = np.zeros(len(values), dtype=WARPED_DTYPE)
         self.upper_warped = np.ones(len(values), dtype=WARPED_DTYPE)
 
+    def warp_f(self, x):
+        return encode(x, self.values, True, WARPED_DTYPE, True)
+
+    def round_to_values(self, y):
+        return decode(y, self.values, True)
+        
     def warp(self, X):
         """Warp inputs to a continuous space.
 

--- a/bayesmark/space.py
+++ b/bayesmark/space.py
@@ -610,7 +610,7 @@ class Categorical(Space):
 
     def round_to_values(self, y):
         return decode(y, self.values, True)
-        
+
     def warp(self, X):
         """Warp inputs to a continuous space.
 


### PR DESCRIPTION
Lambda functions can't be pickled. So if you try to apply multiprocessing to a lambda function, it will fail as Functions are pickled by name, not by code.

Error:


	@classmethod
    def dumps(cls, obj, protocol=None):
        buf = io.BytesIO()
        cls(buf, protocol).dump(obj)
E       AttributeError: Can't pickle local object 'Categorical.__init__.<locals>.<lambda>`